### PR TITLE
 Fix for error in un-compressing file loaded using XMLHttpRequest

### DIFF
--- a/js-unzip.js
+++ b/js-unzip.js
@@ -94,9 +94,9 @@
             this.currentByteIndex = 0;
         },
 
-        // TODO: Other similar JS libs does charCodeAt(index) & 0xff. Grok
-        // why, and do that here if neccesary. So far, I've never gotten a
-        // char code higher than 255.
+		// Using &0xFF to avoid problem with char codes higher than 255 in files loaded using XMLHttpRequest
+		// if you are using a base64 encoded file no need for this
+		// safe to remove & 0xFF
         getByteAt: function (index) {
             return this.stream.charCodeAt(index) & 0xFF;
         },


### PR DESCRIPTION
Scenario: 

I am using js-unzip in a project with js-epub and booktorious. I am loading the epub files using an XMLHttpRequest. I am developing for a mobile platform hence can not do Base64 decoding on the client end as it is fairly slow.

Problem: 

If I use Base64 encoding then there is no problem in un-compressing the file. However when I load an .epub file using a simple  XMLHttpRequest and then pass it to js-epub it fails during "Post processing" phase in the function JSEpub.uncompressNextCompressedFile

Example of Fail Case:

code used to load .epub file downloaded from http://www.epubbooks.com using XMLHttpRequest

```
//serving the file from local server to avoid cross domain error.
var uri = "epubs/finn.epub";    
var req = new XMLHttpRequest();
req.onreadystatechange = function () {
  if (req.readyState == 4 && req.status == 200) {

 //from booktorious
  ebookReader.create(ebookReader.loading).initialize(req.responseText);

  } else if (req.readyState == 4 && req.status < 400 && req.status > 299) {
    console.log('error finding file!');
  } else if (req.readyState == 4) {
    console.log('cross domain loading error');
  }
};
req.overrideMimeType('text/plain; charset=x-user-defined');
req.open("GET", uri);
req.send(null);
```

Solution:

Used what you suggested in the comment for getByteAt: function on line 101. I think using "& 0xFF" should be the default case as it would not be so obvious to everyone. 

Without the fix people will runs into this problem while loading a file using XMLHttpRequest that is not Base64 encoded. And those who do not need this can opt out.
